### PR TITLE
Rename mvn profile to wildfly

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The native application will have to know the absolute path to your server or clu
 
 To produce the native applications run:
 
-    % mvn clean package -Pmobile,jboss7 -Dplatform=android
+    % mvn clean package -Pmobile,wildfly -Dplatform=android
 
 After that you can simply install the native app on your phone or tablet. 
 


### PR DESCRIPTION
Update readme

mvn profile "jboss7" was renamed in pom.xml to "wildfly"
in commit "af7818fc1dd3e0cf1af0a61cd59d4eab5a4c69b7"